### PR TITLE
Split hosts on spaces

### DIFF
--- a/lib/configdata.js
+++ b/lib/configdata.js
@@ -15,7 +15,19 @@ module.exports = function (config_path) {
 
 	var config = require('./configparse').getConfig(config_path);
 	var server_data_header = ["Server Name", "Description", "Tags", "Address"];
-	var server_data = config.map(function(obj){
+	var servers = [];
+	config.map(function(obj){
+		if (obj.host.trim().indexOf(' ') !== -1) {
+			var hosts = obj.host.split(' ');
+			hosts.map(function (host) {
+				var newObj = Object.assign(obj, {host: host});
+				servers.push(JSON.parse(JSON.stringify(newObj)));
+			});
+		} else {
+			servers.push(obj);
+		}
+	});
+	var server_data = servers.map(function(obj){
 		return [
 			obj.host,
 			("description" in obj) ? obj.description : "",


### PR DESCRIPTION
SSH config supports multiple aliases for single servers, like so:

```
Host domaintwo.com domainthree.com
    HostName 90.65.24.78
```
- Previously it did this http://cl.ly/0r3M1K2n0j2F
- Now it does this: http://cl.ly/2B0w1K2T2x18

If this is a welcome change, I'm happy to clean this up/test it/whatever. 

Loving `ssg` so far :)
